### PR TITLE
Introduces functionality to report posts within the application

### DIFF
--- a/src/apis/post.ts
+++ b/src/apis/post.ts
@@ -28,4 +28,8 @@ export const postsApi = {
   // Get posts by a specific seller
   getPostsBySeller: (sellerId: string, filters?: UserPostFilters) =>
     api.get<PaginatedResponse<PostListResponse>>(`${API_ENDPOINTS.posts.byUser(sellerId)}`, { params: filters }),
+
+  // Gửi report bài đăng, không cần body, chỉ cần token
+  reportPost: (postId: string) =>
+    api.put<{ message: string; data: any }>(API_ENDPOINTS.posts.report(postId)),
 };

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -36,6 +36,7 @@ export const API_ENDPOINTS = {
     byUser: (userId: string) => `/post/user/${userId}`,
     create: '/post/create',
     afterCreate: (id: string) => `/post/${id}/after-create`,
+    report: (id: string) => `/post/${id}/report`,
   },
 
   // Categories

--- a/src/pages/PostDetailPage/PostDetailPage.tsx
+++ b/src/pages/PostDetailPage/PostDetailPage.tsx
@@ -152,15 +152,16 @@ export default function PostDetailPage() {
         localStorage.setItem('aloha_report_check_enabled', 'true');
     }
 
-    function isPostReported(postId: string) {
+    function isPostReported(postId: string, userId: string) {
         if (localStorage.getItem('aloha_report_check_enabled') !== 'true') return false;
-        const reported = JSON.parse(localStorage.getItem('aloha_reported_posts') || '{}');
-        return !!reported[postId];
+        const allReported = JSON.parse(localStorage.getItem('aloha_reported_posts') || '{}');
+        return !!(userId && allReported[userId] && allReported[userId][postId]);
     }
-    function setPostReported(postId: string) {
-        const reported = JSON.parse(localStorage.getItem('aloha_reported_posts') || '{}');
-        reported[postId] = true;
-        localStorage.setItem('aloha_reported_posts', JSON.stringify(reported));
+    function setPostReported(postId: string, userId: string) {
+        const allReported = JSON.parse(localStorage.getItem('aloha_reported_posts') || '{}');
+        if (!allReported[userId]) allReported[userId] = {};
+        allReported[userId][postId] = true;
+        localStorage.setItem('aloha_reported_posts', JSON.stringify(allReported));
     }
 
     const [showReportModal, setShowReportModal] = useState(false);
@@ -170,13 +171,13 @@ export default function PostDetailPage() {
         setShowReportModal(true);
     };
     const handleConfirmReport = async () => {
-        if (!post) return;
+        if (!post || !user) return;
         setIsReporting(true);
         try {
             const res = await postsApi.reportPost(post.id);
             const msg = res?.message || res?.data?.message || 'Báo cáo thành công';
             toast.success(msg);
-            setPostReported(post.id);
+            setPostReported(post.id, user.id);
             setShowReportModal(false);
         } catch (err: any) {
             const msg =
@@ -312,8 +313,8 @@ export default function PostDetailPage() {
                                             variant="outline"
                                             size="sm"
                                             onClick={handleReportClick}
-                                            disabled={isPostReported(post.id)}
-                                            className={isPostReported(post.id) ? 'opacity-50 cursor-not-allowed' : ''}
+                                            disabled={isPostReported(post.id, user.id)}
+                                            className={isPostReported(post.id, user.id) ? 'opacity-50 cursor-not-allowed' : ''}
                                         >
                                             <Flag className="w-4 h-4 mr-1" />
                                             Báo cáo

--- a/src/pages/PostDetailPage/PostDetailPage.tsx
+++ b/src/pages/PostDetailPage/PostDetailPage.tsx
@@ -12,6 +12,7 @@ import {
     Share2,
     ChevronLeft,
     ChevronRight,
+    Flag,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
@@ -145,6 +146,44 @@ export default function PostDetailPage() {
         }
     };
 
+    // Xử lý localStorage flag và trạng thái đã report
+    // Đảm bảo flag luôn tồn tại
+    if (typeof window !== 'undefined' && localStorage.getItem('aloha_report_check_enabled') === null) {
+        localStorage.setItem('aloha_report_check_enabled', 'true');
+    }
+
+    function isPostReported(postId: string) {
+        if (localStorage.getItem('aloha_report_check_enabled') !== 'true') return false;
+        const reported = JSON.parse(localStorage.getItem('aloha_reported_posts') || '{}');
+        return !!reported[postId];
+    }
+    function setPostReported(postId: string) {
+        const reported = JSON.parse(localStorage.getItem('aloha_reported_posts') || '{}');
+        reported[postId] = true;
+        localStorage.setItem('aloha_reported_posts', JSON.stringify(reported));
+    }
+
+    const [showReportModal, setShowReportModal] = useState(false);
+    const [isReporting, setIsReporting] = useState(false);
+
+    const handleReportClick = () => {
+        setShowReportModal(true);
+    };
+    const handleConfirmReport = async () => {
+        if (!post) return;
+        setIsReporting(true);
+        try {
+            const res = await postsApi.reportPost(post.id);
+            toast.success(res.message);
+            setPostReported(post.id);
+            setShowReportModal(false);
+        } catch (err: any) {
+            toast.error(err?.message || err?.response?.message || 'Có lỗi xảy ra');
+        } finally {
+            setIsReporting(false);
+        }
+    };
+
     if (isLoading) {
         return (
             <div className="min-h-screen bg-gray-50 flex items-center justify-center">
@@ -261,6 +300,19 @@ export default function PostDetailPage() {
                                     {post.title}
                                 </h1>
                                 <div className="flex items-center gap-2 ml-4">
+                                    {/* Nút Report */}
+                                    {user && user.id !== post.userId && (
+                                        <Button
+                                            variant="outline"
+                                            size="sm"
+                                            onClick={handleReportClick}
+                                            disabled={isPostReported(post.id)}
+                                            className={isPostReported(post.id) ? 'opacity-50 cursor-not-allowed' : ''}
+                                        >
+                                            <Flag className="w-4 h-4 mr-1" />
+                                            Báo cáo
+                                        </Button>
+                                    )}
                                     <Button
                                         variant="outline"
                                         size="sm"
@@ -416,6 +468,24 @@ export default function PostDetailPage() {
                     />
                 </div>
             </div>
+
+            {/* Modal xác nhận báo cáo */}
+            {showReportModal && (
+                <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+                    <div className="bg-white rounded-lg shadow-lg p-6 w-full max-w-sm">
+                        <h2 className="text-lg font-semibold mb-4">Báo cáo bài đăng</h2>
+                        <p className="mb-6">Bạn muốn báo cáo bài đăng này không?</p>
+                        <div className="flex justify-end gap-2">
+                            <Button variant="outline" onClick={() => setShowReportModal(false)} disabled={isReporting}>
+                                Hủy
+                            </Button>
+                            <Button onClick={handleConfirmReport} disabled={isReporting} className="bg-red-600 hover:bg-red-700 text-white">
+                                {isReporting ? 'Đang gửi...' : 'Báo cáo'}
+                            </Button>
+                        </div>
+                    </div>
+                </div>
+            )}
         </div>
     );
 }

--- a/src/pages/PostDetailPage/PostDetailPage.tsx
+++ b/src/pages/PostDetailPage/PostDetailPage.tsx
@@ -174,11 +174,17 @@ export default function PostDetailPage() {
         setIsReporting(true);
         try {
             const res = await postsApi.reportPost(post.id);
-            toast.success(res.message);
+            const msg = res?.message || res?.data?.message || 'Báo cáo thành công';
+            toast.success(msg);
             setPostReported(post.id);
             setShowReportModal(false);
         } catch (err: any) {
-            toast.error(err?.message || err?.response?.message || 'Có lỗi xảy ra');
+            const msg =
+                err?.response?.data?.message ||
+                err?.response?.message ||
+                err?.message ||
+                'Có lỗi xảy ra';
+            toast.error(msg);
         } finally {
             setIsReporting(false);
         }


### PR DESCRIPTION
This pull request introduces functionality to report posts within the application. Key changes include updates to the API, user interface, and local storage handling to support the reporting feature.

### API Enhancements:
* Added a new API method `reportPost` in `src/apis/post.ts` to enable reporting posts by their `postId`.
* Added a new endpoint `report` in `src/constants/index.ts` for reporting posts.

### User Interface Updates:
* Imported the `Flag` icon from `lucide-react` for use in the report button in `PostDetailPage`.
* Added a "Report" button in `PostDetailPage` that allows users to report posts. The button is disabled if the post has already been reported.
* Implemented a modal in `PostDetailPage` for confirming the report action, with a loading state during the reporting process.

### Local Storage Handling:
* Added functions `isPostReported` and `setPostReported` in `PostDetailPage` to manage the reported status of posts using `localStorage`. Ensured the flag for enabling report checks (`aloha_report_check_enabled`) is initialized.